### PR TITLE
Clean up using directives across multiple files

### DIFF
--- a/APIServiceLibrary/DTO/LocationDTO.cs
+++ b/APIServiceLibrary/DTO/LocationDTO.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace APIServiceLibrary.DTO
+﻿namespace APIServiceLibrary.DTO
 {
     public class LocationDTO
     {

--- a/APIServiceLibrary/DTO/NameDTO.cs
+++ b/APIServiceLibrary/DTO/NameDTO.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace APIServiceLibrary.DTO
+﻿namespace APIServiceLibrary.DTO
 {
     public class NameDTO
     {

--- a/APIServiceLibrary/DTO/ResultDTO.cs
+++ b/APIServiceLibrary/DTO/ResultDTO.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace APIServiceLibrary.DTO
+﻿namespace APIServiceLibrary.DTO
 {
     public class ResultDTO
     {

--- a/APIServiceLibrary/DTO/ResultsDTO.cs
+++ b/APIServiceLibrary/DTO/ResultsDTO.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace APIServiceLibrary.DTO
+﻿namespace APIServiceLibrary.DTO
 {
     public class ResultsDTO
     {

--- a/APIServiceLibrary/Services/APIService.cs
+++ b/APIServiceLibrary/Services/APIService.cs
@@ -1,12 +1,6 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using APIServiceLibrary.DTO;
+using Newtonsoft.Json;
 using System.Net.Http.Headers;
-using System.Text;
-using System.Threading.Tasks;
-using APIServiceLibrary.DTO;
-using System.Net.Http;
 
 namespace APIServiceLibrary.Services
 {

--- a/APIServiceLibrary/Services/IAPIService.cs
+++ b/APIServiceLibrary/Services/IAPIService.cs
@@ -1,9 +1,4 @@
 ﻿using APIServiceLibrary.DTO;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace APIServiceLibrary.Services
 {

--- a/CarSimulator.Server/Controllers/CarSimulatorController.cs
+++ b/CarSimulator.Server/Controllers/CarSimulatorController.cs
@@ -4,7 +4,6 @@ using CarSimulator.Server.Models.ViewModels;
 using DataLogicLibrary.Factories;
 using DataLogicLibrary.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
-using System.Diagnostics;
 
 namespace CarSimulator.Server.Controllers
 {

--- a/CarSimulator.Server/Factories/CarFactory.cs
+++ b/CarSimulator.Server/Factories/CarFactory.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using CarSimulator.Server.Models;
+﻿using CarSimulator.Server.Models;
 using DataLogicLibrary.Infrastructure.Enums;
 
 namespace CarSimulator.Server.Factories

--- a/CarSimulator.Server/Factories/DriverFactory.cs
+++ b/CarSimulator.Server/Factories/DriverFactory.cs
@@ -1,10 +1,5 @@
 ﻿using APIServiceLibrary.DTO;
 using CarSimulator.Server.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CarSimulator.Server.Factories
 {

--- a/CarSimulator.Server/Factories/ICarFactory.cs
+++ b/CarSimulator.Server/Factories/ICarFactory.cs
@@ -1,9 +1,4 @@
 ﻿using CarSimulator.Server.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CarSimulator.Server.Factories
 {

--- a/CarSimulator.Server/Factories/IDriverFactory.cs
+++ b/CarSimulator.Server/Factories/IDriverFactory.cs
@@ -1,10 +1,5 @@
 ﻿using APIServiceLibrary.DTO;
 using CarSimulator.Server.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CarSimulator.Server.Factories
 {

--- a/CarSimulator.Server/Models/Car.cs
+++ b/CarSimulator.Server/Models/Car.cs
@@ -1,9 +1,4 @@
 ﻿using DataLogicLibrary.Infrastructure.Enums;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CarSimulator.Server.Models
 {

--- a/CarSimulator.Server/Models/Driver.cs
+++ b/CarSimulator.Server/Models/Driver.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CarSimulator.Server.Models
+﻿namespace CarSimulator.Server.Models
 {
     public class Driver
     {

--- a/DataLogicLibrary/DirectionStrategies/DriveForwardStrategy.cs
+++ b/DataLogicLibrary/DirectionStrategies/DriveForwardStrategy.cs
@@ -1,11 +1,6 @@
-﻿using DataLogicLibrary.Infrastructure.Enums;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DataLogicLibrary.DirectionStrategies.Interfaces;
+﻿using DataLogicLibrary.DirectionStrategies.Interfaces;
 using DataLogicLibrary.DTO;
+using DataLogicLibrary.Infrastructure.Enums;
 
 namespace DataLogicLibrary.DirectionStrategies
 {

--- a/DataLogicLibrary/Services/SimulationLogicService.cs
+++ b/DataLogicLibrary/Services/SimulationLogicService.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
-using DataLogicLibrary.DirectionStrategies.Interfaces;
+﻿using DataLogicLibrary.DirectionStrategies.Interfaces;
 using DataLogicLibrary.DTO;
 using DataLogicLibrary.Infrastructure.Enums;
 using DataLogicLibrary.Services.Interfaces;


### PR DESCRIPTION
Removed unused `using` directives and added necessary ones for the `APIServiceLibrary.DTO` namespace. This includes adjustments in `LocationDTO.cs`, `NameDTO.cs`, `ResultDTO.cs`, `ResultsDTO.cs`, `APIService.cs`, `IAPIService.cs`, `CarFactory.cs`, `DriverFactory.cs`, `ICarFactory.cs`, `IDriverFactory.cs`, `Car.cs`, `Driver.cs`, `DriveForwardStrategy.cs`, and `SimulationLogicService.cs`. These changes improve code readability and maintainability by ensuring only relevant namespaces are included.